### PR TITLE
add cran-comments

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,5 @@
 ^vignettes$
 .github
 ^Dockerfile$
+bump.sh
+cran-comments.md

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,28 @@
+## Test environments
+* local OS X install, R 3.6.3
+* Ubuntu Linux 16.04 LTS, R-release, GCC
+* Fedora Linux, R-devel, clang, gfortran
+* Windows Server 2008 R2 SP1, R-devel, 32/64 bit
+
+## R CMD check results
+There were no ERRORs or WARNINGs. 
+
+There was 1 NOTE:
+
+* checking CRAN incoming feasibility ... NOTE
+  Maintainer: 'Hamish Gibbs <lshhg2@lshtm.ac.uk>'
+  New submission
+  Possibly mis-spelled words in DESCRIPTION:
+  
+  
+    EpiNow (19:20)
+    RtD (19:37)
+    al (18:13)
+    et (18:10)
+    js (17:73)
+    
+  These spellings are intentional. 
+
+## Downstream dependencies
+
+No downstream dependencies.


### PR DESCRIPTION
Adding `cran-comments.md`.

Added `bump.sh` (a convenience for bumping `rt_vis` version) and `cran-comments.md` to `.Rbuildignore`. 

Ran `devtools::check_rhub()` with no errors or warnings.

