### PR TITLE
update default height

### DIFF
--- a/R/define_height.R
+++ b/R/define_height.R
@@ -18,7 +18,7 @@ define_height <- function(geoData, rtData, map_only = F){
     height = height + (225 * 3)
   }
 
-  height = height + 100
+  height = height + 150
 
   return(height)
 

--- a/R/define_height.R
+++ b/R/define_height.R
@@ -1,4 +1,5 @@
-
+# Function to define the default height of the output widget (in pixels)
+# given different data inputs
 
 define_height <- function(geoData, rtData, map_only = F){
 

--- a/tests/testthat/test-define_height.R
+++ b/tests/testthat/test-define_height.R
@@ -1,23 +1,23 @@
 testthat::test_that('define_height works for different dataset combinations', {
-  
+
   height <- define_height(geoData = 'a', rtData = list('a'=list(summaryData = '1', 'a', 'b', 'c', 'd')))
-  
-  testthat::expect_equal(height, 1275)
-  
+
+  testthat::expect_equal(height, 1325)
+
   height <- define_height(geoData = NULL, rtData = list('a'=list(summaryData = '1', 'a', 'b', 'c', 'd')))
-  
-  testthat::expect_equal(height, 1275 - 500)
-  
+
+  testthat::expect_equal(height, 1325 - 500)
+
   height <- define_height(geoData = 'a', rtData = list('a'=list(summaryData = NULL, 'a', 'b', 'c', 'd')))
-  
-  testthat::expect_equal(height, 1275 - 500)
-  
+
+  testthat::expect_equal(height, 1325 - 500)
+
   height <- define_height(geoData = 'a', rtData = list('a'=list(summaryData = '1', 'a', 'b', NULL, 'd')))
-  
-  testthat::expect_equal(height, (1275 - 225))
-  
+
+  testthat::expect_equal(height, (1325 - 225))
+
   height <- define_height(geoData = 'a', rtData = list('a'=list(summaryData = '1', 'a', NULL, NULL, 'd')))
-  
-  testthat::expect_equal(height, (1275 - 225 - 225))
-  
+
+  testthat::expect_equal(height, (1325 - 225 - 225))
+
 })


### PR DESCRIPTION
Changing bottom padding from `100px` to `150px` should prevent bottom content from overlapping time series legend and date slider.

Closes #43.