### PR TITLE
Add download url

### DIFF
--- a/R/summaryWidget.R
+++ b/R/summaryWidget.R
@@ -13,6 +13,7 @@
 #' @param credible_threshold integer, Threshold for credible intervals, maximum observed cases * this value will be removed.
 #' @param width integer, Width of widget in pixels.
 #' @param activeArea string, Area to symbolize first.
+#' @param downloadUrl string, URL to download data.
 #' @param dryRun Logical, defaults to FALSE. Should the function be tested without the widget being created.
 #' Useful for checking the integrity of input data.
 #' @importFrom htmlwidgets createWidget
@@ -30,6 +31,7 @@ summaryWidget <- function(geoData = NULL,
                           credible_threshold=10,
                           width = NULL,
                           activeArea = 'United Kingdom',
+                          downloadUrl = NULL,
                           dryRun = FALSE) {
 
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -38,4 +38,4 @@ YYYY
 zenodo
 Zenodo
 scaleLinear
-
+geo

--- a/man/summaryWidget.Rd
+++ b/man/summaryWidget.Rd
@@ -16,6 +16,7 @@ summaryWidget(
   credible_threshold = 10,
   width = NULL,
   activeArea = "United Kingdom",
+  downloadUrl = NULL,
   dryRun = FALSE
 )
 }
@@ -41,6 +42,8 @@ summaryWidget(
 \item{width}{integer, Width of widget in pixels.}
 
 \item{activeArea}{string, Area to symbolize first.}
+
+\item{downloadUrl}{string, URL to download data.}
 
 \item{dryRun}{Logical, defaults to FALSE. Should the function be tested without the widget being created.
 Useful for checking the integrity of input data.}


### PR DESCRIPTION
Adds `downloadUrl` argument back in so that new RtD3 is backwards compatible with the workflow currently in place in `epiforecasts/covid`. 

Passing or missing this argument will not change anything at the moment but `RtD3js` can be built out again to include a download button for this link. Currently it will not do anything if a string is included for `downloadUrl`.